### PR TITLE
Allow plot height change

### DIFF
--- a/iruby-plotly.gemspec
+++ b/iruby-plotly.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = 'Plot with IRuby'
   s.authors     = ["Zach Capalbo"]
   s.email       = "zach.geek@gmail.com"
-  s.files       = Dir["lib/**/*"] + %w[LICENSE Readme.md]
+  s.files       = Dir["lib/**/*"] + %w[LICENSE README.md]
   s.homepage    = 'https://github.com/zach-capalbo/irub-plotly'
   s.license     = 'MIT'
 end

--- a/lib/iruby-plotly.rb
+++ b/lib/iruby-plotly.rb
@@ -10,19 +10,19 @@ module IRuby
   end
 
   def self.plot(data, options = {})
-        if data.respond_to?(:keys)
-            options = options.merge(data)
-        if data.include?(:xy) then
-          data = data.clone
-          data[:x] = data[:xy].map(&:first)
-          data[:y] = data[:xy].map(&:last)
-          data.delete(:xy)
-        end
-        data = [data]
-      elsif not data.first.respond_to?(:keys)
-        data = [{y:data, x:(1..data.size).to_a}.merge(options)]
+    if data.respond_to?(:keys)
+      options = options.merge(data)
+      if data.include?(:xy) then
+        data = data.clone
+        data[:x] = data[:xy].map(&:first)
+        data[:y] = data[:xy].map(&:last)
+        data.delete(:xy)
       end
-        IRuby.convert({data: data, layout: {height: DEFAULT_PLOT_HEIGHT}.merge(options)}, mime: "application/vnd.plotly.v1+json")
+      data = [data]
+    elsif not data.first.respond_to?(:keys)
+      data = [{y:data, x:(1..data.size).to_a}.merge(options)]
+    end
+    IRuby.convert({data: data, layout: {height: DEFAULT_PLOT_HEIGHT}.merge(options)}, mime: "application/vnd.plotly.v1+json")
   end
 
   def self.plotly(data, layout = {})

--- a/lib/iruby-plotly.rb
+++ b/lib/iruby-plotly.rb
@@ -22,7 +22,7 @@ module IRuby
       elsif not data.first.respond_to?(:keys)
         data = [{y:data, x:(1..data.size).to_a}.merge(options)]
       end
-    IRuby.convert({data: data, layout: options.merge({height: DEFAULT_PLOT_HEIGHT})}, mime: "application/vnd.plotly.v1+json")
+        IRuby.convert({data: data, layout: {height: DEFAULT_PLOT_HEIGHT}.merge(options)}, mime: "application/vnd.plotly.v1+json")
   end
 
   def self.plotly(data, layout = {})


### PR DESCRIPTION
Hello.

Thank you for creating the iruby-plotly gem.

iruby-plot does not allow you to change the height of the plot now.

This is because the default height value overwrites the specified height value.
So I reversed the order of merging hashes.

I would appreciate it if you could accept it. Thank you.